### PR TITLE
Updated requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.10.1
-PyYAML==3.11
-scipy==0.16.1
-TextGrid==1.1
+numpy==1.12.0
+PyYAML==3.12
+scipy==0.18.1
+TextGrid==1.4


### PR DESCRIPTION
A friend was trying to install Prosodylab-Aligner and because this requirements.txt file was outdated, the libraries weren't actually being installed and it wouldn't install. With updated versions, it works!