### PR TITLE
Fixed "'float' object cannot be interpreted as an integer" error

### DIFF
--- a/aligner/wavfile.py
+++ b/aligner/wavfile.py
@@ -69,7 +69,7 @@ class WavFile(object):
 
     def _resample(self, Fs_out):
         ratio = Fs_out / self.Fs
-        resampled_signal = resample(self.signal, ratio * len(self))
+        resampled_signal = resample(self.signal, int(ratio * len(self)))
         return resampled_signal
 
     def resample(self, Fs_out):


### PR DESCRIPTION
This error occurred during resampling. Typical example:

Resampling '/tmp/input.wav'.
Traceback (most recent call last):
File "/opt/anaconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
"main", mod_spec)
File "/opt/anaconda3/lib/python3.7/runpy.py", line 85, in _run_code
exec(code, run_globals)
File "/tmp/Prosodylab-Aligner/aligner/main.py", line 126, in
corpus = Corpus(args.align, opts)
File "/tmp/Prosodylab-Aligner/aligner/corpus.py", line 91, in init
self._prepare_audio(audiofiles)
File "/tmp/Prosodylab-Aligner/aligner/corpus.py", line 210, in _prepare_audio
w.resample_bang(self.samplerate)
File "/tmp/Prosodylab-Aligner/aligner/wavfile.py", line 79, in resample_bang
self.signal = self._resample(Fs_out)
File "/tmp/Prosodylab-Aligner/aligner/wavfile.py", line 72, in _resample
resampled_signal = resample(self.signal, ratio * len(self))
File "/opt/anaconda3/lib/python3.7/site-packages/scipy/signal/signaltools.py", line 2221, in resample
Y = zeros(newshape, 'D')
TypeError: 'float' object cannot be interpreted as an integer

The error is due to passing a 'float' argument to a SciPy function that
expects an 'int' parameter.