### PR TITLE
Implemented multiple-dictionary support

### DIFF
--- a/aligner/__main__.py
+++ b/aligner/__main__.py
@@ -51,8 +51,8 @@ argparser = ArgumentParser(prog="{} -m aligner".format(sys.executable),
                            description="Prosodylab-Aligner")
 argparser.add_argument("-c", "--configuration",
                        help="config file")
-argparser.add_argument("-d", "--dictionary", default=DICTIONARY,
-                       help="dictionary file (default: {})".format(DICTIONARY))
+argparser.add_argument("-d", "--dictionary", metavar="DICT", action="append",
+                       help="dictionary file (default: {}) (can specify multiple)".format(DICTIONARY))
 argparser.add_argument("-s", "--samplerate", type=int,
                        help="analysis samplerate (in Hz)")
 argparser.add_argument("-e", "--epochs", type=int,
@@ -73,6 +73,10 @@ verbosity_group.add_argument("-v", "--verbose", action="store_true",
 verbosity_group.add_argument("-V", "--extra-verbose", action="store_true",
                              help="Even more verbose output")
 args = argparser.parse_args()
+
+# hack to allow proper override of default dictionary
+if not args.dictionary:
+    args.dictionary = [DICTIONARY]
 
 # set up logging
 loglevel = logging.WARNING

--- a/aligner/corpus.py
+++ b/aligner/corpus.py
@@ -67,9 +67,14 @@ class Corpus(object):
                 logging.error("Phone '{}': not /{}/.".format(phone,
                                                       VALID_PHONE))
                 exit(1)
-        # dictionary
-        self.dictionary = opts["dictionary"]
-        self.thedict = PronDict(self.dictionary, self.phoneset)
+        # dictionaries
+        self.dictionary = []
+        if "dictionary" in opts and opts["dictionary"]:
+            assert type(opts["dictionary"]) is list
+            self.dictionary.extend(opts["dictionary"])
+        self.thedict = PronDict(self.phoneset)
+        for dic in self.dictionary:
+            self.thedict.add(dic)
         #self.thedict[SIL] = [SIL]
         self.taskdict = os.path.join(self.tmpdir, "taskdict")
         # word and phone lists
@@ -173,8 +178,8 @@ class Corpus(object):
                              "-g", temp,
                              "-w", self.words,
                              "-n", self.phons,
-                             self.taskdict,
-                             self.dictionary])
+                             self.taskdict] +
+                   self.dictionary)
         # add SIL to phone list
         with open(self.phons, "a") as phons:
             print(SIL, file=phons)

--- a/aligner/prondict.py
+++ b/aligner/prondict.py
@@ -51,16 +51,21 @@ class PronDict(object):
                 exit(1)
             yield (i, word, pron.split())
 
-    def __init__(self, filename, phoneset):
+    def add(self, filename):
         # build up dictionary
         with open(filename, "r") as source:
-            self.d = defaultdict(list)
             for (i, word, pron) in PronDict.pronify(source):
                 for ph in pron:
-                    if ph not in phoneset | self.SILENT_PHONES:
+                    if ph not in self.ps | self.SILENT_PHONES:
                         logging.error("Unknown phone '{}' in dictionary '{}' (ln. {}).".format(ph, filename, i))
                         exit(1)
                 self.d[word].append(pron)
+
+    def __init__(self, phoneset, filename=None):
+        self.ps = phoneset
+        self.d = defaultdict(list)
+        if filename:
+            self.add(filename)
         # for later...
         self.oov = set()
 


### PR DESCRIPTION
First draft of multi-dictionary support. Includes logic to filter out blank lines and `#` comments (in addition to `;` comments, which were already implemented).

Usage example:
```
python3 -m aligner -d eng.dict -d my.dict -a /tmp/files/
```